### PR TITLE
Se quito los metadatos de spectrum segmentation.

### DIFF
--- a/app/src/components/organisms/BBList.tsx
+++ b/app/src/components/organisms/BBList.tsx
@@ -14,8 +14,12 @@ interface BoxListProps {
   classes: BBClassesProps[]
   parameters: BBListParameters
 }
+export enum Step {
+  Plate,
+  Spectrum
+}
 interface BBListParameters {
-  fieldsMetadata: boolean
+  step: Step
 }
 
 export function BoxList({ boundingBoxes, setBoundingBoxes, selected, setSelected, classes, parameters }: BoxListProps) {
@@ -187,7 +191,7 @@ function ItemOfBoxList({
           <hr />
         )}
         <div>
-          {isSelected && (
+          {isSelected && parameters.step == Step.Plate && (
             <BoxMetadataForm ref={boxMetadataFormRef} onChange={handleFormChange} />
           )}
         </div>

--- a/app/src/components/organisms/BBUI.tsx
+++ b/app/src/components/organisms/BBUI.tsx
@@ -8,7 +8,7 @@ import { nanoid } from "nanoid"
 import { useCallback, useState } from "react"
 import { Button } from "../atoms/button"
 import { Card } from "../atoms/card"
-import { BoxList } from "./BBList"
+import { BoxList, Step } from "./BBList"
 import { ImageLoader } from "./ImageLoader"
 import { ImageViewer } from "./ImageViewer"
 
@@ -27,7 +27,7 @@ interface BBUIProps {
 interface BBUIParameters {
   rotateButton: boolean
   invertColorButton: boolean
-  fieldsMetadata: boolean
+  step: Step
 }
 
 export function BBUI({
@@ -161,18 +161,18 @@ export function BBUI({
         >
           {image
             ? (
-                <ImageViewer
-                  src={image}
-                  rotation={rotation}
-                  bgWhite={bgWhite}
-                  isDrawingMode={isDrawingMode}
-                  setIsDrawingMode={setIsDrawingMode}
-                  selectedBoxId={selectedBoxId}
-                  setSelectedBoxId={setSelectedBoxId}
-                  boundingBoxes={boundingBoxes}
-                  setBoundingBoxes={setBoundingBoxes}
-                />
-              )
+              <ImageViewer
+                src={image}
+                rotation={rotation}
+                bgWhite={bgWhite}
+                isDrawingMode={isDrawingMode}
+                setIsDrawingMode={setIsDrawingMode}
+                selectedBoxId={selectedBoxId}
+                setSelectedBoxId={setSelectedBoxId}
+                boundingBoxes={boundingBoxes}
+                setBoundingBoxes={setBoundingBoxes}
+              />
+            )
             : <ImageLoader handleImageLoad={handleImageLoad} />}
         </div>
       </Card>
@@ -182,7 +182,7 @@ export function BBUI({
         selected={selectedBoxId}
         setSelected={setSelectedBoxId}
         classes={classes}
-        parameters={{ fieldsMetadata: parameters.fieldsMetadata }}
+        parameters={{ step: parameters.step }}
       />
       <div className="flex justify-center pt-4">
         <Button

--- a/app/src/components/pages/StepPlateSegmentation.tsx
+++ b/app/src/components/pages/StepPlateSegmentation.tsx
@@ -5,12 +5,13 @@ import { useGlobalStore } from "@/hooks/use-global-store"
 import { usePredictBBs } from "@/hooks/use-predict-BBs"
 import { useState } from "react"
 import { BBUI } from "../organisms/BBUI"
+import { Step } from "../organisms/BBList"
 
 export function StepPlateSegmentation({ index, processInfo, setProcessInfo }: StepProps) {
   const parameters = {
     rotateButton: true,
     invertColorButton: true,
-    fieldsMetadata: true,
+    step: Step.Plate,
   }
   const [boundingBoxes, setBoundingBoxes] = useState<BoundingBox[]>(
     processInfo.data.spectrums.map(spec => spec.spectrumBoundingBox),
@@ -70,8 +71,8 @@ export function StepPlateSegmentation({ index, processInfo, setProcessInfo }: St
           state: index === i
             ? "COMPLETE"
             : (index + 1 === i
-                ? "NECESSARY_CHANGES"
-                : step.state),
+              ? "NECESSARY_CHANGES"
+              : step.state),
         })),
         specificSteps: prev.processingStatus.specificSteps.map((step, i) => ({
           ...step,

--- a/app/src/components/pages/StepSpectrumSegmentation.tsx
+++ b/app/src/components/pages/StepSpectrumSegmentation.tsx
@@ -6,12 +6,13 @@ import { usePredictBBs } from "@/hooks/use-predict-BBs"
 import { cropImages } from "@/lib/cropImage"
 import { useEffect, useState } from "react"
 import { BBUI } from "../organisms/BBUI"
+import { Step } from "../organisms/BBList"
 
 export function StepSpectrumSegmentation({ index, processInfo, setProcessInfo }: StepProps) {
   const parameters = {
     rotateButton: false,
     invertColorButton: false,
-    fieldsMetadata: false,
+    step: Step.Spectrum,
   }
   const [setActualStep, selectedSpectrum] = useGlobalStore(s => [
     s.setActualStep,


### PR DESCRIPTION
Complete #208.
Tiempo 1 hs.

Resolvi este issue con la opcion de parametrizar el mostrar o no, ya que el componente BBlist tiene logica que depende del componente BoxMetadataForm. Seguro se puede pasar el componente por parametro pero seria complicar demas en mi opinion.
Para mi la mejor opcion a largo plazo es refactorizar BBUI para que solo abarque el canvas, quedando a fuera los botones como girar, invertir colores y tambien que haya un componente que tenga los datos de los bounding box. asi se puede crear dos componentes uno para cada step, y agregar solo componentes necesarios para esa etapa.