### PR TITLE
fix: El modelo tiene que cargar en el docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV PORT=3000
 WORKDIR /app
 
 COPY --from=builder /app/.output ./.output
+COPY --from=builder /app/app/models ./app/models
 
 EXPOSE 3000
 


### PR DESCRIPTION
El modelo detector de observaciones que se usa dentro del servidor no se cargaba dentro del docker. Se modifico el Dockerfile para que la carpeta del modelos que se usan del lado del servidor sean cargadas en el mismo
