### PR TITLE
fix: [ID-271] 🎨 Agregar BoundingBox con colores diferentes

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -28,9 +28,11 @@ export function simpleHash(str: string) {
  * and then getting a color from a predefined palette.
  */
 export function idToColor(id: string): string {
-  const colors = ["red", "blue", "green"]
-  const index = simpleHash(id) % colors.length
-  return colors[index]
+  const hue = simpleHash(id) % 360
+  const saturation = 65
+  const lightness = 50
+  let res = `hsl(${hue} ${saturation}% ${lightness}%)`
+  return res
 }
 
 /**
@@ -38,17 +40,15 @@ export function idToColor(id: string): string {
  */
 export function idxToColor(idx: number): string {
   const colors = [
-    "#e6194b",
-    "#3cb44b",
-    "#4363d8",
-    "#911eb4",
-    "#46f0f0",
-    "#f032e6",
-    "#f58231",
-    "#bcf60c",
-    "#fabebe",
-    "#008080",
+    "red",
+    "orange",
+    "yellow",
+    "green",
+    "blue",
+    "indigo",
+    "violet",
   ]
+  console.log("in", idx, "out", colors[idx % colors.length])
   return colors[idx % colors.length]
 }
 

--- a/app/routes/_app/observation.$observationId/-components/SpectrumsList.tsx
+++ b/app/routes/_app/observation.$observationId/-components/SpectrumsList.tsx
@@ -6,7 +6,7 @@ import { Button } from "~/components/ui/button"
 import { Card, CardContent } from "~/components/ui/card"
 import { usePredictBBs } from "~/hooks/use-predict-BBs"
 import { notifyError } from "~/lib/notifications"
-import { cn } from "~/lib/utils"
+import { cn, idToColor } from "~/lib/utils"
 import { classesSpectrumDetection } from "~/types/BBClasses"
 import { addSpectrum } from "../-actions/add-spectrum"
 import { addSpectrums } from "../-actions/add-spectrums"
@@ -26,7 +26,7 @@ export function spectrumToBoundingBox(spectrum: Spectrum): BoundingBox {
   return {
     id: spectrum.id,
     name: "",
-    color: spectrum.type === "science" ? "red" : "green",
+    color: idToColor(spectrum.id),
     top: spectrum.imageTop,
     left: spectrum.imageLeft,
     width: spectrum.imageWidth,

--- a/app/routes/_app/observation.$observationId/-utils/spectrum-to-bounding-box.ts
+++ b/app/routes/_app/observation.$observationId/-utils/spectrum-to-bounding-box.ts
@@ -1,6 +1,6 @@
-import type { BoundingBox } from "~/components/BoundingBoxer"
-import { idToColor } from "~/lib/utils"
-import type { getSpectrums } from "../-actions/get-spectrums"
+import type { BoundingBox } from "~/components/BoundingBoxer";
+import { idToColor } from "~/lib/utils";
+import type { getSpectrums } from "../-actions/get-spectrums";
 
 export type Spectrum = Awaited<ReturnType<typeof getSpectrums>>[number]
 

--- a/app/routes/_app/plate.$plateId/-components/ObservationsList.tsx
+++ b/app/routes/_app/plate.$plateId/-components/ObservationsList.tsx
@@ -6,7 +6,7 @@ import { Button } from "~/components/ui/button"
 import { Card, CardContent } from "~/components/ui/card"
 import { formatObservation } from "~/lib/format"
 import { notifyError } from "~/lib/notifications"
-import { cn, idxToColor } from "~/lib/utils"
+import { cn, idToColor } from "~/lib/utils"
 import { addObservation } from "../-actions/add-observation"
 import { addObservations } from "../-actions/add-observations"
 import { deleteObservation } from "../-actions/delete-observation"
@@ -20,7 +20,7 @@ function observationToBoundingBox(observation: Observation): BoundingBox {
     id: observation.id,
     name: observation.name,
     label: formatObservation(observation),
-    color: "red",
+    color: idToColor(observation.id),
     top: observation.imageTop,
     left: observation.imageLeft,
     width: observation.imageWidth,
@@ -42,10 +42,7 @@ export function ObservationsList({
   const router = useRouter()
   const [boundingBoxes, setBoundingBoxes] = useState<BoundingBox[]>(
     sortByLabel(
-      initialObservations.map((obs, idx) => ({
-        ...observationToBoundingBox(obs),
-        color: idxToColor(idx),
-      })),
+      initialObservations.map(observationToBoundingBox),
     ),
   )
 


### PR DESCRIPTION
Se modifico la función que crea las bounding box, para poder configurar el color basado en el id de la observación.
Se modificó la función idToColor para poder tomar un rango más amplio de colores, reduciendo la posibilidad de que se repitan los colores. Se utiliza la luminizidad y la intensidad del color para poder diferenciar mejor los colores.

Caso positivo: 
<img width="1415" height="523" alt="image" src="https://github.com/user-attachments/assets/5fa6402a-ae5c-42b0-8ef1-fdf14f428841" />

Caso con colores similares:
<img width="1434" height="528" alt="image" src="https://github.com/user-attachments/assets/3bb069a9-3260-4ec5-a0e4-cda2e725f0b2" />

Nota: Basarce en el id de la observación provoca que al hacer el hash queden colores similares, en algunos casos, por lo que a futuro puede facilar mucho más utilizar ids autoincrementales y hacer el modulo de ese ID, para buscar en un rango de colores más acotado, o simplemente definir un nuevo campo 'Orden' para numerar las observaciones en la imagén.